### PR TITLE
Create tg-bot docker compose

### DIFF
--- a/tg_bot/.dockerignore
+++ b/tg_bot/.dockerignore
@@ -1,0 +1,16 @@
+venv
+.git
+db.sqlite3
+.env
+.vscode
+.pytest-cache
+.coverage
+.coveragerc
+htmlcov
+coverage*
+*.http
+*-dev*
+
+# github images
+/media/github/
+tmp

--- a/tg_bot/Dockerfile
+++ b/tg_bot/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11
+WORKDIR /app
+COPY . .
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt

--- a/tg_bot/docker-compose.yml
+++ b/tg_bot/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.3'
+
+services:
+  bot:
+    build: .
+    container_name: tg-bot
+    command: python main.py
+    ports:
+      - 8000:80
+    volumes:
+      - ./:/app
+    env_file:
+      - .env
+    restart: always


### PR DESCRIPTION
# Docker compose

Докер реализован пока без докер-хаба. В режиме разработки контейнер будет пересобираться при каждом запуске `docker-compose`.

Для запуска бота на сервере необходимо:

1. Убедиться что на сервере установлены `docker` и `docker-compose`. Если их нет - установить и настроить.

2. Обновить кодовую базу на сервере:
```
git pull
```
3. Перейти в директорию бота:
```
cd tg-bot/
```
4. Запустить бот в контейнере:
```
docker-compose up --build -d
```
5. Для остановки работы бота:
```
docker-compose down
```